### PR TITLE
fix(types): correct type for default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage
 assertion:
 
 ```javascript
-import retry = from 'retry-assert';
+import * as retry from 'retry-assert';
 import { expect } from 'expect';
 
 async function getUser (id) {
@@ -40,7 +40,7 @@ console.log(activeUser);
 assertion fails:
 
 ```javascript
-import retry from 'retry-assert';
+import * as retry from 'retry-assert';
 import { expect } from 'expect';
 
 async function getUser (id) {

--- a/retry-assert.d.ts
+++ b/retry-assert.d.ts
@@ -155,4 +155,4 @@ interface RetryBuilder<T> {
 
 declare module 'retry-assert';
 
-export default retry;
+export = retry;


### PR DESCRIPTION
Using the example code from the readme:

```ts
import retry from 'retry-assert';
```
results in:

```
    TypeError: (0 , retry_assert_1.default) is not a function
```
changing it to:

```ts
import * as retry from 'retry-assert';
```

results in TS throwing the following error:
```
This expression is not callable.
  Type 'typeof import("/Users/.../node_modules/retry-assert/retry-assert")' has no call signatures. ts(2349)
```

From what I understand, since this is a CommonJS default export, the `d.ts` signature should be `export = retry`.
